### PR TITLE
build: conventional commit enforcement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+---
+repos:
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: master
+    hooks:
+      - id: commitizen
+        stages: [commit-msg]

--- a/docs/contributor.md
+++ b/docs/contributor.md
@@ -1,0 +1,16 @@
+
+# Contributor guide
+
+## Conventionnal commit
+
+Install `pre-commit` on your system. For example, using the `nix` package manager:
+
+```bash
+nix-env -e pre-commit
+```
+
+Then activate the GIT hook located in [`.pre-commit-config.yaml`](../.pre-commit-config.yaml).
+
+```
+pre-commit install --hook-type commit-msg
+```


### PR DESCRIPTION
An example on how to manually apply conventional commit to your local repository, see #3.