### PR TITLE
docs: list ports and protocols

### DIFF
--- a/docs/ports.md
+++ b/docs/ports.md
@@ -15,7 +15,7 @@
 
 - NameNode
 
-  - Metadata HTTPS service
+  - HTTPS service
 
     The namenode secure HTTP server address and port. It provides access to the HDFS web UI.
 
@@ -27,25 +27,23 @@
 
     External access: yes
 
-    [Source](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml)
+    [Source](https://hadoop.apache.org/docs/r3.1.1/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml)
     
     Verified
 
-  - Metadata RPC service
+  - RPC service
 
-    Main RPC port used by client to communicate with HDFS using a binary protocol. The port is embedded in the URI, eg `hdfs://nn1.domain.com:9820/`.
+    Main RPC port used by client to communicate with HDFS using a binary protocol. The port is embedded in the URI, eg `hdfs://nn1.domain.com:8020/`.
 
-    Port: 9820
+    Port: 8020
 
     Protocol: IPC
 
-    Property: `fs.defaultFS`
+    Property: `dfs.namenode.rpc-address`
 
     External access: yes
 
-    [Source](https://hadoop.apache.org/docs/r3.0.0/hadoop-project-dist/hadoop-hdfs/HDFSHighAvailabilityWithNFS.html)
-
-    [Source](https://issues.apache.org/jira/browse/HDFS-9427)
+    [Source](https://hadoop.apache.org/docs/r3.1.1/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml)
     
     Verified
 
@@ -63,9 +61,7 @@
 
     External access: no
 
-    [Source](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml)
-
-    [Source](https://github.com/TOSIT-FR/hadoop/blob/5b1fa3e1aabb6bd350bf5dbd4f4e49578d94738f/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java)
+    [Source](https://hadoop.apache.org/docs/r3.1.1/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml)
 
     Verified
 
@@ -73,9 +69,9 @@
 
   - Secure data transfert
 
-    The datanode server address and port for data transfer.  The value depends on the usage of SASL to authenticate data transfer protocol instead of running the DataNode as root, learn more about [securing the DataNode](https://cwiki.apache.org/confluence/display/HADOOP/Secure+DataNode).
+    The datanode server address and port for data transfer. The value depends on the usage of SASL to authenticate data transfer protocol instead of running the DataNode as root, learn more about [securing the DataNode](https://cwiki.apache.org/confluence/display/HADOOP/Secure+DataNode).
 
-    Port: 9866 (SASL based IPC, non-privileged port) 1004 (privileged port) 
+    Port: 9866 (SASL based IPC, non-privileged port) or 1004 (privileged port) 
 
     Protocol: IPC
 
@@ -83,21 +79,17 @@
 
     External access: no
 
-    [Source privileged port](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/SecureMode.html)
+    [Source privileged port](https://hadoop.apache.org/docs/r3.1.1/hadoop-project-dist/hadoop-common/SecureMode.html)
 
-    [Source non-privilege port](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml)
-
-    [Source](https://github.com/TOSIT-FR/hadoop/blob/5b1fa3e1aabb6bd350bf5dbd4f4e49578d94738f/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileContext.java)
-
-    [Source](https://github.com/TOSIT-FR/hadoop/blob/5b1fa3e1aabb6bd350bf5dbd4f4e49578d94738f/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java)
+    [Source non-privilege port](https://hadoop.apache.org/docs/r3.1.1/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml)
 
     [Source](https://issues.apache.org/jira/browse/HDFS-9427)
 
     Verified
 
-  - Metadata HTTPS service
+  - HTTPS service
 
-    The datanode secure HTTP server address and port. It is used to access the status, logs, etc, and file data                                operations when using [WebHDFS](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/WebHDFS.html) or [HttpFS](https://hadoop.apache.org/docs/current/hadoop-hdfs-httpfs/index.html) (was [HFTP](https://hadoop.apache.org/docs/r1.2.1/hftp.html) in prior versions). The NameNode UI redirect the user to the DataNode server when browsing files.
+    The datanode secure HTTP server address and port. It is used to access the status, logs, etc, and file data operations when using [WebHDFS](https://hadoop.apache.org/docs/r3.1.1/hadoop-project-dist/hadoop-hdfs/WebHDFS.html) or [HttpFS](https://hadoop.apache.org/docs/r3.1.1/hadoop-hdfs-httpfs/index.html). The NameNode UI redirects the user to the DataNode server when browsing files.
 
     Port: 9865
 
@@ -107,13 +99,11 @@
 
     External access: yes
 
-    [Source](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml)
-
-    [Source](https://github.com/TOSIT-FR/hadoop/blob/5b1fa3e1aabb6bd350bf5dbd4f4e49578d94738f/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java)
+    [Source](https://hadoop.apache.org/docs/r3.1.1/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml)
 
     Verified
 
-  - Metadata RPC service
+  - RPC service
 
     The DataNode RCP server address and port used for metadata information.
 
@@ -125,9 +115,7 @@
 
     External access: (requires Apache Knox) 
 
-    [Source](https://hadoop.apache.org/docs/r3.0.0/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml)
-
-    [Source](https://github.com/TOSIT-FR/hadoop/blob/5b1fa3e1aabb6bd350bf5dbd4f4e49578d94738f/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.jav)
+    [Source](https://hadoop.apache.org/docs/r3.1.1/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml)
 
     [Source](https://issues.apache.org/jira/browse/HDFS-9427)
     
@@ -147,9 +135,7 @@
 
     External access: no
 
-    [Source](https://hadoop.apache.org/docs/r3.0.0/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml)
-    
-    [Source](https://github.com/TOSIT-FR/ansible-tdp-roles/blob/cadf02e0a849b878b9510a29c30aa3144d9aa789/roles/hadoop/defaults/main.yaml)
+    [Source](https://hadoop.apache.org/docs/r3.1.1/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml)
     
     Verified
 
@@ -165,9 +151,7 @@
 
     External access: no
 
-    [Source](https://hadoop.apache.org/docs/r3.0.0/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml)
-
-    [Source](hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java)
+    [Source](https://hadoop.apache.org/docs/r3.1.1/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml)
 
     Verified
 
@@ -187,9 +171,7 @@
 
     External access: no
 
-    [Source](https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-common/yarn-default.xml)
-
-    [Source](hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java)
+    [Source](https://hadoop.apache.org/docs/r3.1.1/hadoop-yarn/hadoop-yarn-common/yarn-default.xml)
   
     Verified
 
@@ -205,12 +187,8 @@
 
     External access: yes
 
-    [Source default port](https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-common/yarn-default.xml)
+    [Source default port](https://hadoop.apache.org/docs/r3.1.1/hadoop-yarn/hadoop-yarn-common/yarn-default.xml)
     [Source YARN HA port](https://community.cloudera.com/t5/Support-Questions/What-is-the-default-Yarn-resource-manager-port-Is-it-8032-or/td-p/138143)
-
-    [Source](hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRMHA.java)
-
-    [Source](https://github.com/TOSIT-FR/hadoop/blob/5b1fa3e1aabb6bd350bf5dbd4f4e49578d94738f/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java)
 
     Verified
 
@@ -226,9 +204,7 @@
 
     External access: yes
 
-    [Source](https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-common/yarn-default.xml)
-
-    [Source](https://github.com/TOSIT-FR/ansible-tdp-roles/blob/cadf02e0a849b878b9510a29c30aa3144d9aa789/roles/hadoop/defaults/main.yaml)
+    [Source](https://hadoop.apache.org/docs/r3.1.1/hadoop-yarn/hadoop-yarn-common/yarn-default.xml)
 
     Verified
 
@@ -244,7 +220,7 @@
 
     External access: yes
 
-    [Source](https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-common/yarn-default.xmlhttps://github.com/TOSIT-FR/hadoop/blob/5b1fa3e1aabb6bd350bf5dbd4f4e49578d94738f/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml)
+    [Source](https://hadoop.apache.org/docs/r3.1.1/hadoop-yarn/hadoop-yarn-common/yarn-default.xml)
 
     Verified
 
@@ -278,11 +254,7 @@
 
     External access: yes
 
-    [Source](https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-common/yarn-default.xml)
-
-    [Source](https://github.com/TOSIT-FR/ansible-tdp-roles/blob/cadf02e0a849b878b9510a29c30aa3144d9aa789/roles/hadoop/defaults/main.yaml)
-
-    [Source](https://github.com/TOSIT-FR/hadoop/blob/5b1fa3e1aabb6bd350bf5dbd4f4e49578d94738f/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml)
+    [Source](https://hadoop.apache.org/docs/r3.1.1/hadoop-yarn/hadoop-yarn-common/yarn-default.xml)
 
     Verified
 
@@ -298,7 +270,7 @@
 
     External access: no
 
-    [Source](https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-common/yarn-default.xml)
+    [Source](https://hadoop.apache.org/docs/r3.1.1/hadoop-yarn/hadoop-yarn-common/yarn-default.xml)
 
     Verified
 
@@ -314,9 +286,7 @@
 
     External access: yes
 
-    [Source](https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-common/yarn-default.xml)
-
-    [Source](https://github.com/TOSIT-FR/ansible-tdp-roles/blob/cadf02e0a849b878b9510a29c30aa3144d9aa789/roles/hadoop/defaults/main.yaml)
+    [Source](https://hadoop.apache.org/docs/r3.1.1/hadoop-yarn/hadoop-yarn-common/yarn-default.xml)
 
     Verified
 
@@ -346,7 +316,7 @@
 
     External access: yes
 
-    [Source](https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-common/yarn-default.xml)
+    [Source](https://hadoop.apache.org/docs/r3.1.1/hadoop-yarn/hadoop-yarn-common/yarn-default.xml)
 
   - HTTPS server
 
@@ -360,13 +330,10 @@
 
     External access: yes
 
-    [Source](https://github.com/TOSIT-FR/hadoop/blob/5b1fa3e1aabb6bd350bf5dbd4f4e49578d94738f/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml)
-
-    [Source](https://github.com/TOSIT-FR/hadoop/blob/5b1fa3e1aabb6bd350bf5dbd4f4e49578d94738f/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java)
-    
-    [Source](https://github.com/TOSIT-FR/hadoop/blob/5b1fa3e1aabb6bd350bf5dbd4f4e49578d94738f/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/timeline/security/TestTimelineAuthenticationFilterForV1.java)
+    [Source](https://hadoop.apache.org/docs/r3.1.1/hadoop-yarn/hadoop-yarn-common/yarn-default.xml)
 
     Verified
+
 ## MapReduce Job History Server
 
 - Job History RPC server
@@ -381,11 +348,7 @@
 
   External access: yes
 
-  [Source](https://hadoop.apache.org/docs/stable/hadoop-mapreduce-client/hadoop-mapreduce-client-core/mapred-default.xml)
-
-  [Source](https://github.com/TOSIT-FR/ansible-tdp-roles/blob/cadf02e0a849b878b9510a29c30aa3144d9aa789/roles/hadoop/defaults/main.yaml)
-
-  [Source](https://github.com/TOSIT-FR/hadoop/blob/5b1fa3e1aabb6bd350bf5dbd4f4e49578d94738f/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/resources/mapred-default.xml)
+  [Source](https://hadoop.apache.org/docs/r3.1.1/hadoop-mapreduce-client/hadoop-mapreduce-client-core/mapred-default.xml)
 
   Verified
 
@@ -401,9 +364,7 @@
 
   External access: yes
 
-  [Source](https://github.com/TOSIT-FR/hadoop/blob/5b1fa3e1aabb6bd350bf5dbd4f4e49578d94738f/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/resources/mapred-default.xml)
-
-  [Source](https://github.com/TOSIT-FR/hadoop/blob/5b1fa3e1aabb6bd350bf5dbd4f4e49578d94738f/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-common/src/main/java/org/apache/hadoop/mapreduce/v2/jobhistory/JHAdminConfig.java)
+  [Source](https://hadoop.apache.org/docs/r3.1.1/hadoop-mapreduce-client/hadoop-mapreduce-client-core/mapred-default.xml)
 
   Verified
 
@@ -419,9 +380,7 @@
 
   External access: no
 
-  [Source](https://hadoop.apache.org/docs/stable/hadoop-mapreduce-client/hadoop-mapreduce-client-core/mapred-default.xmlhttps://github.com/TOSIT-FR/hadoop/blob/5b1fa3e1aabb6bd350bf5dbd4f4e49578d94738f/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-shuffle/src/main/java/org/apache/hadoop/mapred/ShuffleHandler.java)
-
-  [Source](https://github.com/TOSIT-FR/hadoop/blob/5b1fa3e1aabb6bd350bf5dbd4f4e49578d94738f/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-shuffle/src/main/java/org/apache/hadoop/mapred/ShuffleHandler.java)
+  [Source](https://hadoop.apache.org/docs/r3.1.1/hadoop-mapreduce-client/hadoop-mapreduce-client-core/mapred-default.xml)
 
   Verified
 
@@ -437,7 +396,7 @@
 
   External access: no
 
-  [Source](https://github.com/TOSIT-FR/hadoop/blob/5b1fa3e1aabb6bd350bf5dbd4f4e49578d94738f/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/resources/mapred-default.xmlhttps://hadoop.apache.org/docs/stable/hadoop-mapreduce-client/hadoop-mapreduce-client-core/mapred-default.xml)
+  [Source](https://hadoop.apache.org/docs/r3.1.1/hadoop-mapreduce-client/hadoop-mapreduce-client-core/mapred-default.xml)
 
   Verified
 
@@ -451,17 +410,11 @@
 
   Protocol: RPC
 
-  Property: `zookeeper.port` (`clientPort` in `zoo.cnf` files)
+  Property: `clientPort` in `zoo.cfg` file
 
-  External access: no
+  External access: yes
 
-  [Source](https://zookeeper.apache.org/doc/r3.4.9/zookeeperAdmin.html#sc_configurationhttps://zookeeper.apache.org/doc/r3.4.6/zookeeperAdmin.html#sc_configuration)
-
-  [Source](https://github.com/TOSIT-FR/hadoop/blob/5b1fa3e1aabb6bd350bf5dbd4f4e49578d94738f/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml)
-
-  [Source](https://github.com/TOSIT-FR/ansible-tdp-roles/blob/0f62840bd064c7334aa7f89f21e3695ca6952b50/roles/zookeeper/templates/zoo.cfg.j2)
-
-  [Source](https://github.com/TOSIT-FR/hadoop/blob/5b1fa3e1aabb6bd350bf5dbd4f4e49578d94738f/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/main/java/org/apache/hadoop/yarn/service/utils/ZookeeperUtils.java)
+  [Source](https://zookeeper.apache.org/doc/r3.4.6/zookeeperAdmin.html#sc_configuration)
 
   Verified
 
@@ -473,13 +426,11 @@
 
   Protocol: RPC
 
-  Property: `zookeeper.peer_port`
+  Property: `server.x:y:2888:3888` in `zoo.cfg` file
 
   External access: no
 
-  [Source](https://zookeeper.apache.org/doc/r3.4.9/zookeeperAdmin.html#sc_configurationhttps://zookeeper.apache.org/doc/r3.4.6/zookeeperAdmin.html#sc_configuration)
-
-  [Source](https://github.com/TOSIT-FR/ansible-tdp-roles/blob/2d2d97e2e45f89861fcf0dbdd74d5a603df6062c/roles/zookeeper/defaults/main.yml)
+  [Source](https://zookeeper.apache.org/doc/r3.4.6/zookeeperAdmin.html#sc_configuration)
 
   Verified
 
@@ -491,13 +442,11 @@
 
   Protocol: RPC
 
-  Property: `zookeeper.leader_port`
+  Property: `server.x:y:2888:3888` in `zoo.cfg` file
 
   External access: no
 
-  [Source](https://zookeeper.apache.org/doc/r3.4.9/zookeeperAdmin.html#sc_configurationhttps://zookeeper.apache.org/doc/r3.4.6/zookeeperAdmin.html#sc_configuration)
-
-  [Source](https://github.com/TOSIT-FR/ansible-tdp-roles/blob/2d2d97e2e45f89861fcf0dbdd74d5a603df6062c/roles/zookeeper/defaults/main.yml)
+  [Source](https://zookeeper.apache.org/doc/r3.4.6/zookeeperAdmin.html#sc_configuration)
 
   Verified
 
@@ -516,10 +465,6 @@
   External access: yes
 
   [Source](https://cwiki.apache.org/confluence/display/Hive/Configuration+Properties)
-  
-  [Source](https://github.com/TOSIT-FR/hive/blob/0c5e9e0aae48324335cfeae757e2d37258207b3c/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java)
-
-  [Source](https://github.com/TOSIT-FR/hive/blob/0c5e9e0aae48324335cfeae757e2d37258207b3c/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java)
 
   Verified
 
@@ -527,7 +472,7 @@
 
   The JDBC/ODBC interface to the Hive Metastore.
 
-  Port: 10000
+  Port: 10000 (in TCP) or 10001 (in HTTP)
 
   Protocol: RPC
 
@@ -536,8 +481,6 @@
   External access: yes
 
   [Source](https://cwiki.apache.org/confluence/display/Hive/Configuration+Properties)
-
-  [Source](https://github.com/TOSIT-FR/hive/blob/0c5e9e0aae48324335cfeae757e2d37258207b3c/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java)
 
   Verified
 
@@ -555,9 +498,8 @@
 
   [Source](https://cwiki.apache.org/confluence/display/Hive/Configuration+Properties)
 
-  [Source](https://github.com/TOSIT-FR/hive/blob/0c5e9e0aae48324335cfeae757e2d37258207b3c/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java)
-
   Verified
+
 ## Ranger
 
 - Policy Manager
@@ -572,11 +514,10 @@
 
   External access: yes
 
-  [Source](https://github.com/apache/ranger/blob/7e80592481306bb0711f7a7544b2c6c64cbebadf/security-admin/src/main/resources/conf.dist/ranger-admin-site.xml)
-
   [Source](https://github.com/TOSIT-FR/ranger/blob/4992a349905451939951c994b0bb18bd584f59a3/security-admin/scripts/ranger-admin-site-template.xml)
 
   Verified
+
 ## Oozie
 
 - Web UI
@@ -591,11 +532,7 @@
 
   External access: yes
 
-  [Source](https://github.com/apache/oozie/blob/f1e01a9e155692aa5632f4573ab1b3ebeab7ef45/docs/src/site/markdown/AG_Install.md)
-
-  [Source](https://github.com/TOSIT-FR/oozie/blob/a15fedba1baeb5186ac86f54457a27ef4b738b88/sharelib/oozie/src/test/resources/instrumentation-os-env.json)
-
-  [Source](https://github.com/apache/oozie/blob/f1e01a9e155692aa5632f4573ab1b3ebeab7ef45/core/src/main/resources/oozie-default.xml)
+  [Source](https://oozie.apache.org/docs/4.3.1/AG_Install.html)
 
   Verified
 
@@ -611,9 +548,7 @@
 
   External access: no
 
-  [Source](https://github.com/TOSIT-FR/oozie/blob/a15fedba1baeb5186ac86f54457a27ef4b738b88/sharelib/oozie/src/test/resources/instrumentation-os-env.json)
-
-  [Source](https://oozie.apache.org/docs/3.3.2/AG_Install.html)
+  [Source](https://oozie.apache.org/docs/4.3.1/AG_Install.html)
   
   Verified
 
@@ -631,14 +566,15 @@
 
   External access: yes
 
-  [Source](https://github.com/TOSIT-FR/knox/blob/3c3f23a866d55de563c6574353019858590367d8/gateway-release/home/conf/gateway-site.xml)
+  [Source](https://github.com/TOSIT-FR/knox/blob/v1.0.0-TDP/gateway-server/src/main/resources/conf/gateway-default.xml)
   
   Verified
 
 ## Additionnal resources
 
 - [CDH ports](https://docs.cloudera.com/documentation/enterprise/6/6.3/topics/cdh_ports.html)
-- [HDFS default configuration](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml)
-- [YARN default configuration](https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-common/yarn-default.xml)
-- [MapReduce default configuration](https://hadoop.apache.org/docs/stable/hadoop-mapreduce-client/hadoop-mapreduce-client-core/mapred-default.xml)
+- [CDP ports](https://docs.cloudera.com/cdp-private-cloud-base/7.1.7/installation/topics/cdpdc-ports-used-by-runtime.html)
+- [HDFS default configuration](https://hadoop.apache.org/docs/r3.1.1/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml)
+- [YARN default configuration](https://hadoop.apache.org/docs/r3.1.1/hadoop-yarn/hadoop-yarn-common/yarn-default.xml)
+- [MapReduce default configuration](https://hadoop.apache.org/docs/r3.1.1/hadoop-mapreduce-client/hadoop-mapreduce-client-core/mapred-default.xml)
 - [HDFS should not default to ephemeral ports](https://issues.apache.org/jira/browse/HDFS-9427)


### PR DESCRIPTION
The current list cover Hadoop HDFS, YARN and MapReduce, ZooKeeper, Hive, Ranger, Oozie and Knox. It needs some review as even the Cloudera and Hortonworks documentation contains errors. More information on the usage of a given port and the usage/population it addresses would be useful.