### PR TITLE
feat(github): conventional commit enforcement github action

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,11 @@
+name: Conventional Commits
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+jobs:
+  check-conventional-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: webiny/action-conventional-commits@v1.0.3
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .*
+!.github
 !.gitignore


### PR DESCRIPTION
Fix #3 

This PR uses the [action-conventional-commits](https://github.com/webiny/action-conventional-commits) GitHub action to enforce [Conventional Commits](https://www.conventionalcommits.org/).

The use of a linter such as [commitlint](https://github.com/conventional-changelog/commitlint) will be evaluated later once we are comfortable with our conventional commit patterns.