### PR TITLE
add jupyterhub dependencies

### DIFF
--- a/build-env/Dockerfile
+++ b/build-env/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get -q update \
     libbz2-dev \
     libcurl4-openssl-dev \
     libfuse-dev \
+    libkrb5-dev \
     libprotobuf-dev \
     libprotoc-dev \
     libsasl2-dev \
@@ -72,8 +73,10 @@ RUN apt-get -q update \
     python \
     python2.7 \
     python-pip \
+    python3-dev \
     python3-pip \
     python3-setuptools \
+    python3-venv \
     python-pkg-resources \
     python-setuptools \
     python-wheel \
@@ -147,20 +150,42 @@ RUN python3 -m pip install --upgrade pip
 
 ####
 # Install pandas and pyarrow for Spark 3
+# venv-pack for jupyterhub venv
 ####
 RUN python3 -m pip install numpy==1.19.5 \
     pandas==1.0.5 \
-    pyarrow==4.0.1
+    pyarrow==4.0.1 \
+    venv-pack==0.2.0
+
+###
+# Set nvm environment variables to tune installation
+###
+# node.js 10.x by default
+ENV NODE_VERSION 10.24.1
+ENV NVM_DIR /usr/local/nvm
+ENV NODE_PATH $NVM_DIR/versions/node/v$NODE_VERSION/lib/node_modules
+ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+
+###
+# Install nvm to manage multiple version of node.js (install node.js 10.x by default)
+###
+run mkdir -p $NVM_DIR \
+    && curl -L -s -S https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.2/install.sh | bash
 
 ###
 # Install node.js 10.x for web UI framework (4.2.6 ships with Xenial)
 ###
 # hadolint ignore=DL3008
-RUN curl -L -s -S https://deb.nodesource.com/setup_10.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
+RUN source $NVM_DIR/nvm.sh \
+    && nvm alias default lts/dubnium \
+    && nvm use default \
     && npm install -g bower@1.8.8
+
+###
+# Install node.js 16.x for jupyterhub extensions
+###
+RUN source $NVM_DIR/nvm.sh \
+    && nvm install 16.18.1
 
 ###
 ## Install Yarn 1.12.1 for web UI framework

--- a/build-env/README.md
+++ b/build-env/README.md
@@ -14,7 +14,7 @@ The Docker image in `Dockerfile` is based on the one provided in the official [i
 
 The image can be built and tagged with:
 
-```
+```bash
 docker build . -t tdp-builder
 ```
 
@@ -26,7 +26,7 @@ The container needs to start as root to create the `builder` user so do not run 
 
 The container should be started with:
 
-```
+```bash
 docker run --rm=true -t -i \
   -v "${TDP_HOME:-${PWD}}:/tdp" \
   -w "/tdp" \


### PR DESCRIPTION
<!--  Thank you for sending a pull request! Please make sure:

1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->


#### Additional comments:
<!--
Example: `"I was not sure if it is the right way to do but..."
-->
This PR adds necessary dependencies to create a `jupyterhub` release.

To create the `jupyterlab` (part of the yarn venv), we need node >= 12. Therefore, I added a way to manage multiple versions of nodejs.
The default version when using `node` is still 10.X.

If you need to switch to node 16.X, use the commands:
```bash
source /usr/local/nvm/nvm.sh
nvm use lts/gallium # or nvm use 16
```

#### Agreements

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/), you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
 - [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
