### PR TITLE
feat: dood & gradle

### DIFF
--- a/build-env/Dockerfile
+++ b/build-env/Dockerfile
@@ -20,6 +20,8 @@
 
 FROM ubuntu:bionic
 
+ARG DOCKER_GID_BUILD
+
 WORKDIR /root
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -88,6 +90,7 @@ RUN apt-get -q update \
     sudo \
     valgrind \
     zlib1g-dev \
+    unzip \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -169,7 +172,7 @@ ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 ###
 # Install nvm to manage multiple version of node.js (install node.js 10.x by default)
 ###
-run mkdir -p $NVM_DIR \
+RUN mkdir -p $NVM_DIR \
     && curl -L -s -S https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.2/install.sh | bash
 
 ###
@@ -246,5 +249,21 @@ RUN curl -L -o hugo.deb https://github.com/gohugoio/hugo/releases/download/v0.58
     && dpkg --install hugo.deb \
     && rm hugo.deb
 
+# Install gradle 8.1.1
+RUN  mkdir -p /opt/gradle \
+    && curl -L https://services.gradle.org/distributions/gradle-8.1.1-bin.zip -o gradle-8.1.1-bin.zip \
+    && unzip gradle-8.1.1-bin.zip \
+    && mv gradle-8.1.1 /opt/gradle \
+    && rm gradle-8.1.1-bin.zip 
+
+ENV GRADLE_HOME=/opt/gradle/gradle-8.1.1
+ENV PATH=$PATH:$GRADLE_HOME/bin
+
+# Install Docker
+RUN curl https://get.docker.com/builds/Linux/x86_64/docker-latest.tgz | tar xvz -C /tmp/ && mv /tmp/docker/docker /usr/bin/docker
+
+RUN groupadd -g $DOCKER_GID_BUILD docker
+
 COPY docker-entrypoint.sh /usr/local/bin/
+
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/build-env/README.md
+++ b/build-env/README.md
@@ -25,6 +25,7 @@ docker run --rm=true -t -i \
   -v "${TDP_HOME:-${PWD}}:/tdp" \
   -w "/tdp" \
   -v "${HOME}/.m2:/home/builder/.m2${V_OPTS:-}" \
+  -v "/var/run/docker.sock:/var/run/docker.sock" \
   -e "BUILDER_UID=$(id -u)" \
   -e "BUILDER_GID=$(id -g)" \
   -e "BUILDER_GROUPS=docker" \

--- a/build-env/README.md
+++ b/build-env/README.md
@@ -9,7 +9,7 @@ The Docker image in `Dockerfile` is based on the one provided in the official [i
 The image can be built and tagged with:
 
 ```bash
-docker build . -t tdp-builder
+docker build . -t tdp-builder --build-arg DOCKER_GID_BUILD=$(getent group docker | cut -d: -f3)
 ```
 
 This image contains an entrypoint that create a `builder` user on the fly if you specify `BUILDER_UID` and `BUILDER_GID` as environment variables. This allow to have a `builder` user with the same `uid` and `gid` as the host user. If these variables are not defined, the `builder` user will not be created.
@@ -27,6 +27,7 @@ docker run --rm=true -t -i \
   -v "${HOME}/.m2:/home/builder/.m2${V_OPTS:-}" \
   -e "BUILDER_UID=$(id -u)" \
   -e "BUILDER_GID=$(id -g)" \
+  -e "BUILDER_GROUPS=docker" \
   --ulimit nofile=500000:500000 \
   tdp-builder
 ```

--- a/build-env/docker-entrypoint.sh
+++ b/build-env/docker-entrypoint.sh
@@ -12,6 +12,14 @@ if [[ -n "$BUILDER_UID" ]] && [[ -n "$BUILDER_GID" ]]; then
         chown builder:builder /home/builder
         gosu builder cp -r /etc/skel/. /home/builder
     fi
+    if [[ -n "$BUILDER_GROUPS" ]]; then
+        IFS=","
+        read line <<<$BUILDER_GROUPS
+        FIELDS=( $line )
+        for f in ${FIELDS[@]} ; do
+            usermod -aG $f builder
+        done
+    fi
     # Avoid changing dir if a work dir is specified
     [[ "$PWD" == "/root" ]] && cd /home/builder
     if [[ -z "$@" ]]; then


### PR DESCRIPTION
To allow to build iceberg with TDP builder, we need builder to access docker and gradle. I have arbitrarily chosen to use dood and not dind for docker.
Dood is using host docker through socket which is mounted in container.
Gradle is installed from archive.