### PR TITLE
feat: script to check if TDP branch have been rebased on the build br…

### DIFF
--- a/bin/check-component-branch-rebase.sh
+++ b/bin/check-component-branch-rebase.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# The script checks if the branches ending with '-TDP' have been rebased on their corresponding '-build' branch in each component's repository.
+
+# Go to the folder which contains all theses repositories and execute this script.
+
+# List of repositories
+repositories=(
+    "hadoop"
+    "tez"
+    "spark-hive"
+    "spark"
+    "hive"
+    "hbase"
+    "ranger"
+    "phoenix"
+    "phoenix-queryserver"
+    "knox"
+    "hbase-connectors"
+    "hbase-operator-tools"
+)
+
+# Function to check branches
+check_branches() {
+    cd "$1" || return
+    echo "Checking repository: $(basename "$1")"
+    
+    # Fetch latest changes from remote
+    git fetch origin
+
+    # Initialize an empty array
+    build_branches=()
+
+    # Read each line of the command output into the array
+    while IFS= read -r branch; do
+        # Append each branch to the array
+        build_branches+=("$branch")
+    done < <(git branch -r --list 'origin/*-build')
+
+    # Check if the array is empty
+    if [ ${#build_branches[@]} -eq 0 ]; then
+        echo "No branches matching the pattern 'origin/*-build' found."
+    else
+        # Loop through each branch in the array
+        for ((i=0; i<${#build_branches[@]}; i++)); do
+            # Replace "-build" with "-TDP" for each branch
+            tdp_branch=${build_branches[i]/-build/-TDP}
+            echo "Build branch: ${build_branches[i]}"
+            # Check if TDP branch contains the build branch
+            if git merge-base --is-ancestor ${build_branches[i]} $tdp_branch; then
+                echo "Branch -TDP is based on -build branch"
+            else
+                echo "Error: Branch -TDP is not based on -build branch"
+            fi
+        done
+    fi
+    cd ..
+}
+
+# Loop through each repository
+for repo in "${repositories[@]}"; do
+    check_branches "$repo"
+    echo ""
+done


### PR DESCRIPTION
The script checks if the branches ending with '-TDP' have been rebased on their corresponding '-build' branch in each component's repository.

output:

```
./TDP/bin/check-component-branch-rebase.sh
Checking repository: hadoop
Build branch:   origin/branch-3.1.1-build
Branch -TDP is based on -build branch

Checking repository: tez
Build branch:   origin/branch-0.9.1-build
Error: Branch -TDP is not based on -build branch
Build branch:   origin/branch-0.9.2-build
Branch -TDP is based on -build branch

Checking repository: spark-hive
Build branch:   origin/release-1.2.1-spark2-build
Branch -TDP is based on -build branch

Checking repository: spark
Build branch:   origin/branch-2.3.4-build
Branch -TDP is based on -build branch
Build branch:   origin/branch-3.2.4-build
Branch -TDP is based on -build branch

Checking repository: hive
Build branch:   origin/branch-2.3.9-build
Branch -TDP is based on -build branch
Build branch:   origin/branch-3.1.3-build
Branch -TDP is based on -build branch

Checking repository: hbase
Build branch:   origin/branch-2.1.10-build
Branch -TDP is based on -build branch

Checking repository: ranger
Build branch:   origin/ranger-2.0-build
Branch -TDP is based on -build branch

Checking repository: phoenix
Build branch:   origin/branch-5.1.3-build
Branch -TDP is based on -build branch

Checking repository: phoenix-queryserver
Build branch:   origin/branch-6.0.0-build
Branch -TDP is based on -build branch

Checking repository: knox
Build branch:   origin/branch-1.6.1-build
Branch -TDP is based on -build branch

Checking repository: hbase-connectors
Build branch:   origin/branch-2.3.4-1.0.0-build
Branch -TDP is based on -build branch

Checking repository: hbase-operator-tools
Build branch:   origin/branch-1.1.0-build
Branch -TDP is based on -build branch
```