### PR TITLE
feat(build-env): add libpam to tdp-builder

### DIFF
--- a/build-env/Dockerfile
+++ b/build-env/Dockerfile
@@ -58,6 +58,7 @@ RUN apt-get -q update \
     libcurl4-openssl-dev \
     libfuse-dev \
     libkrb5-dev \
+    libpam0g-dev \
     libprotobuf-dev \
     libprotoc-dev \
     libsasl2-dev \


### PR DESCRIPTION
[Apache Ranger pom.xml has a profile enabled if the lib pam headers are found on the host/](https://github.com/TOSIT-IO/ranger/blob/45f01cf9fdda27a109c39959d3eaedae574ee360/pom.xml#L548-L561). This profile enables the module unixauthpam.

This module simply compile a .c file, and the resulting binary is included in the distributed .tar.gz

This binary can then be used as an auth provider for the unixauthservice of the ranger-usersync. This binary uses Linux PAM as an authentication provider.

While this module is really not mandatory, I think it is worth bundling. Also it is built this way by other distros.